### PR TITLE
Bump constrictive upper bounds.

### DIFF
--- a/configifier.cabal
+++ b/configifier.cabal
@@ -36,11 +36,11 @@ library
     , bytestring >=0.10 && <0.11
     , case-insensitive >=1.2 && <1.3
     , containers >=0.5 && <0.6
-    , either >=4.3 && <4.4
+    , either >=4.3 && <4.5
     , mtl >=2.1 && <2.3
     , regex-easy >=0.1.0.0 && <0.2
     , safe >=0.3 && <0.4
-    , string-conversions >=0.3 && <0.4
+    , string-conversions >=0.3 && <0.5
     , unordered-containers >=0.2 && <0.3
     , vector >=0.10 && <0.11
     , yaml >=0.8 && <0.9
@@ -70,7 +70,7 @@ executable configifier-example
     , bytestring >=0.10 && <0.11
     , mtl >=2.1 && <2.3
     , pretty-show >=1.6.8 && <1.7
-    , string-conversions >=0.3.0.3 && <0.4
+    , string-conversions >=0.3.0.3 && <0.5
     , text >=1.2 && <1.3
     , yaml >=0.8 && <0.9
 
@@ -102,8 +102,8 @@ test-suite tests
     , hspec-discover >= 2.1.3 && < 2.2
     , mtl >=2.1 && <2.3
     , pretty-show >= 1.6.8 && < 1.7
-    , QuickCheck >= 2.7.6 && < 2.8
+    , QuickCheck >= 2.7.6 && < 2.9
     , scientific >= 0.3.3.5 && < 0.4
-    , string-conversions >= 0.3.0.3 && < 0.4
+    , string-conversions >= 0.3.0.3 && < 0.5
     , unordered-containers >= 0.2.5.1 && < 0.3
     , vector >= 0.10.12.2 && < 0.11


### PR DESCRIPTION
```
    Bump upper bounds for 'either', 'string-conversions', and 'QuickCheck'.
```
